### PR TITLE
Support encoding Unicode CSV output

### DIFF
--- a/src/feeddb/explorer/unicodecsv.py
+++ b/src/feeddb/explorer/unicodecsv.py
@@ -1,0 +1,27 @@
+import csv
+import codecs
+import cStringIO
+
+
+class UnicodeWriter:
+    def __init__(self, f, dialect=csv.excel, encoding="utf-8-sig", **kwds):
+        self.queue = cStringIO.StringIO()
+        self.writer = csv.writer(self.queue, dialect=dialect, **kwds)
+        self.stream = f
+        self.encoder = codecs.getincrementalencoder(encoding)()
+
+    def writerow(self, row):
+        """writerow(unicode) -> None
+        This function takes a Unicode string and encodes it to the output.
+        """
+        self.writer.writerow([unicode(s).encode("utf-8")
+                              for s in row])
+        data = self.queue.getvalue()
+        data = data.decode("utf-8")
+        data = self.encoder.encode(data)
+        self.stream.write(data)
+        self.queue.truncate(0)
+
+    def writerows(self, rows):
+        for row in rows:
+            self.writerow(row)

--- a/src/feeddb/explorer/views.py
+++ b/src/feeddb/explorer/views.py
@@ -21,6 +21,9 @@ from django.contrib import messages
 
 import os.path
 
+from unicodecsv import UnicodeWriter
+
+
 def portal_page(request):
     c = RequestContext(request, {'title': 'FeedDB Explorer', 'content': 'Welcome!'  })
     return render_to_response('explorer/index.html', c, mimetype="text/html")
@@ -212,7 +215,7 @@ def bucket_download(request, id):
             full_filename = "%s/trials.csv" % tempdir
             filenames["trials.csv"]=full_filename
 
-            metaWriter = csv.writer(open(full_filename,"w"), delimiter=delimiter_char,  doublequote='false' , escapechar ='\\', quotechar=quotechar_char, quoting=csv.QUOTE_MINIMAL)
+            metaWriter = UnicodeWriter(open(full_filename,"w"), delimiter=delimiter_char,  doublequote='false' , escapechar ='\\', quotechar=quotechar_char, quoting=csv.QUOTE_MINIMAL)
 
             #output trials
             #output headers
@@ -271,7 +274,7 @@ def bucket_download(request, id):
                 filenames[filename]=full_filename
 
                 f = open(full_filename,"w")
-                metaWriter = csv.writer(f, delimiter=delimiter_char, doublequote='false', escapechar ='\\', quotechar=quotechar_char, quoting=csv.QUOTE_MINIMAL)
+                metaWriter = UnicodeWriter(f, delimiter=delimiter_char, doublequote='false', escapechar ='\\', quotechar=quotechar_char, quoting=csv.QUOTE_MINIMAL)
                 metaWriter.writerow(headers)
                 objects={}
                 for lineup in trial.session.channellineup_set.all():
@@ -362,7 +365,7 @@ def bucket_download(request, id):
                 full_filename = "%s/channels.dat" % tempdir
                 filenames[filename]=full_filename
                 f = open(full_filename,"w")
-                metaWriter = csv.writer(f, delimiter=delimiter_char, doublequote='false', escapechar ='\\', quotechar=quotechar_char, quoting=csv.QUOTE_MINIMAL)
+                metaWriter = UnicodeWriter(f, delimiter=delimiter_char, doublequote='false', escapechar ='\\', quotechar=quotechar_char, quoting=csv.QUOTE_MINIMAL)
                 metaWriter.writerow(channel_headers)
                 trial_readers={}
                 total_trial_number=0


### PR DESCRIPTION
This fixes the Tupaia Belangeri metadata download issue. The apostrophe in 'Belanger’s Treeshrews' is a U+2019 right single quotation mark character and CSV output was encoding to ASCII where that character was not converted implicitly.